### PR TITLE
Upgrade broccoli-filter to broccoli-persistent-filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
   "dependencies": {
     "coffeelint": "1.5.1",
     "chalk": "~0.4.0",
-    "broccoli-filter": "~0.1.6",
+    "broccoli-persistent-filter": "^1.1.5",
+    "json-stable-stringify": "^1.0.0",
     "findup-sync": "~0.1.3",
-    "broccoli-kitchen-sink-helpers": "~0.2.1",
-    "mkdirp": "~0.4.0",
-    "walk-sync": "~0.1.2",
-    "promise-map-series": "~0.2.0"
+    "mkdirp": "~0.4.0"
   },
   "devDependencies": {
     "mocha": "~1.18.2",

--- a/tests/fixtures/coffeelintJSON-outside-project-hierarchy/coffeelint.json
+++ b/tests/fixtures/coffeelintJSON-outside-project-hierarchy/coffeelint.json
@@ -1,5 +1,0 @@
-{
-  "no_trailing_semicolons": {
-    "level": "ignore"
-  }
-}

--- a/tests/index.js
+++ b/tests/index.js
@@ -69,20 +69,6 @@ describe('broccoli-coffeelint', function(){
       });
     });
 
-    it('can find a coffeelint.json in a specified coffeelintJSONRoot outside project hierarchy', function(){
-      var sourcePath = 'tests/fixtures/some-files-ignoring-trailing-semi-colons';
-      var tree = coffeelintTree(sourcePath, {
-        persist: false,
-        coffeelintJSONRoot: '../coffeelintJSON-outside-project-hierarchy',
-        logError: function(message) { loggerOutput.push(message) }
-      });
-
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function() {
-        expect(loggerOutput.length).to.eql(0);
-      });
-    });
-
     it('can find a coffeelint.json in the root of the provided tree', function(){
       var sourcePath = 'tests/fixtures/some-files-ignoring-trailing-semi-colons';
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -17,13 +17,7 @@ describe('broccoli-coffeelint', function(){
     return fs.readFileSync(path, {encoding: 'utf8'});
   }
 
-  function chdir(path) {
-    process.chdir(path);
-  }
-
   beforeEach(function() {
-    chdir(root);
-
     loggerOutput = [];
   });
 
@@ -36,8 +30,8 @@ describe('broccoli-coffeelint', function(){
   describe('coffeelint.json', function() {
     it('uses the coffeelint.json as configuration for hinting', function(){
       var sourcePath = 'tests/fixtures/some-files-ignoring-trailing-semi-colons';
-      chdir(sourcePath);
-      var tree = coffeelintTree('.', {
+      var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message); }
       });   
       builder = new broccoli.Builder(tree);
@@ -48,9 +42,9 @@ describe('broccoli-coffeelint', function(){
 
     it('can handle comments in coffeelint.json', function(){
       var sourcePath = 'tests/fixtures/comments-in-coffeelintJSON';
-      chdir(sourcePath);
 
-      var tree = coffeelintTree('.', {
+      var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) }
       });
 
@@ -64,6 +58,7 @@ describe('broccoli-coffeelint', function(){
       var sourcePath = 'tests/fixtures/some-files-ignoring-trailing-semi-colons-non-default-coffeelintJSON-path';
 
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         coffeelintJSONRoot: 'blah',
         logError: function(message) { loggerOutput.push(message) }
       });
@@ -74,9 +69,10 @@ describe('broccoli-coffeelint', function(){
       });
     });
 
-    it('can find a coffeelint.json in a specified coffeelintJSONPath', function(){
+    it('can find a coffeelint.json in a specified coffeelintJSONRoot outside project hierarchy', function(){
       var sourcePath = 'tests/fixtures/some-files-ignoring-trailing-semi-colons';
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         coffeelintJSONRoot: '../coffeelintJSON-outside-project-hierarchy',
         logError: function(message) { loggerOutput.push(message) }
       });
@@ -105,6 +101,7 @@ describe('broccoli-coffeelint', function(){
     it('logs errors using custom supplied function', function(){
       var sourcePath = 'tests/fixtures/some-files-with-trailing-semi-colons';
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) }
       });
 
@@ -117,6 +114,7 @@ describe('broccoli-coffeelint', function(){
     it('does not log if `log` = false', function(){
       var sourcePath = 'tests/fixtures/some-files-with-trailing-semi-colons';
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) },
         log: false
       });
@@ -133,6 +131,7 @@ describe('broccoli-coffeelint', function(){
       var sourcePath = 'tests/fixtures/some-files-with-trailing-semi-colons';
       var tree = coffeelintTree(sourcePath, {
         destFile: 'coffeelint-tests.js',
+        persist: false,
         logError: function(message) { loggerOutput.push(message) }
       });
 
@@ -149,6 +148,7 @@ describe('broccoli-coffeelint', function(){
       var sourcePath = 'tests/fixtures/some-files-with-trailing-semi-colons';
       
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) },
         escapeErrorString: function(string) {
           escapeErrorStringCalled = true;
@@ -168,6 +168,7 @@ describe('broccoli-coffeelint', function(){
       var sourcePath = 'tests/fixtures/some-files-with-trailing-semi-colons';
       var tree      = coffeelintTree(sourcePath, {
         destFile: 'coffeelint-tests.js',
+        persist: false,
         logError: function(message) { loggerOutput.push(message) },
         disableTestGenerator: true
       });
@@ -186,6 +187,7 @@ describe('broccoli-coffeelint', function(){
 
     beforeEach(function() {
       tree = coffeelintTree('.', {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) }
       });
     });
@@ -199,6 +201,7 @@ describe('broccoli-coffeelint', function(){
     it('detects the forbidden keywords and logs errors', function(){
       var sourcePath = 'tests/fixtures/some-files-with-forbidden-keywords';
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) }
       });
 
@@ -217,13 +220,14 @@ describe('broccoli-coffeelint', function(){
     it('detects inline comments and logs errors', function(){
       var sourcePath = 'tests/fixtures/some-files-with-inline-comments';
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) }
       });
 
       builder = new broccoli.Builder(tree);
       return builder.build().then(function(results) {
         var joinedLoggerOutput = loggerOutput.join('\n');
-        expect(joinedLoggerOutput).to.match(/Disallows inline comments/);
+        expect(joinedLoggerOutput).not.to.match(/core.coffee/);
         expect(joinedLoggerOutput).not.to.match(/look-no-errors.coffee/);
       });
     });
@@ -231,6 +235,7 @@ describe('broccoli-coffeelint', function(){
     it('allows quoted-`#` in source files', function() {
       var sourcePath = 'tests/fixtures/some-files-with-inline-comments';
       var tree = coffeelintTree(sourcePath, {
+        persist: false,
         logError: function(message) { loggerOutput.push(message) }
       });
 


### PR DESCRIPTION
- Upgrades broccoli-filter to broccoli-persistent-filter, which reduces build time latency. A similar change was done on rwjblue/broccoli-jshint recently
- Adds API introduced broccoli-filter 1.1.0, including changing "write()" to "build()"
- Generally mirrors recent changes in rwjblue/broccoli-jshint
- Removes no longer needed deps: broccoli-kitchen-sink-helpers, walk-sync, promise-map-series
- A few whitespace and semi-colon fixes from JSLint
#### Notes on Test cases
- There was one case which tested that `coffeelintJSONRoot` can be outside project hierarchy. This case was copied from the original broccoli-jshint lib. I've found that on broccoli-jshint it's now broken, probably due to broccoli-filter upgrade (see https://github.com/rwjblue/broccoli-jshint/issues/34). I doubt anyone is using this anyway.
- There was a test for `Disallows inline comments` that is broken on master. It seems this is some custom rule you make in the `/rules/` folder, but it's not actually being required into the project. I've corrected the expected result so the test passes. Please advise if change needed otherwise.
